### PR TITLE
Fix fallback import for sentiment model

### DIFF
--- a/langchain_z3.py
+++ b/langchain_z3.py
@@ -16,7 +16,9 @@ import conversation as convo
 
 try:
     from rf_model import analyze_sentiment
-except ImportError:
+except Exception:
+    # Fall back to a dummy sentiment analyzer if the model cannot be loaded
+    # (e.g. missing pickle files or other import issues)
     def analyze_sentiment(_text: str) -> str:
         return "Netral"
 


### PR DESCRIPTION
## Summary
- handle any exception when importing `rf_model`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685e2fa31e70832daa8ca3bb6a716d31