### PR TITLE
Lazy load heavy modules

### DIFF
--- a/app/agents/rag.py
+++ b/app/agents/rag.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 from typing import Literal
 
-from app.services.vector import get_retriever
-from app.services.search import search_web
 from app.services.logger import logger
 
 def retrieve_context(
@@ -15,6 +13,8 @@ def retrieve_context(
     contexts = []
 
     if mode in {"docs", "all"}:
+        from app.services.vector import get_retriever
+
         retriever = get_retriever()
         docs = retriever.get_relevant_documents(query, k=k_docs)
         if docs:
@@ -26,6 +26,8 @@ def retrieve_context(
         logger.debug("RAG.docs", found=len(docs))
 
     if mode in {"web", "all"}:
+        from app.services.search import search_web
+
         snippets = search_web(query, k=k_web)
         if snippets:
             context_web = "\n".join(

--- a/app/services/search.py
+++ b/app/services/search.py
@@ -1,9 +1,21 @@
-from langchain_community.tools.ddg_search.tool import DuckDuckGoSearchRun
+from typing import TYPE_CHECKING
 
-search_tool = DuckDuckGoSearchRun()
+if TYPE_CHECKING:
+    from langchain_community.tools.ddg_search.tool import DuckDuckGoSearchRun
+
+_search_tool: "DuckDuckGoSearchRun" | None = None
+
+def _get_search_tool() -> "DuckDuckGoSearchRun":
+    global _search_tool
+    if _search_tool is None:
+        from langchain_community.tools.ddg_search.tool import DuckDuckGoSearchRun
+
+        _search_tool = DuckDuckGoSearchRun()
+    return _search_tool
 
 def search_web(query: str, k: int = 3) -> list[str]:
-    result = search_tool.invoke(query)
+    tool = _get_search_tool()
+    result = tool.invoke(query)
     if isinstance(result, str):
         return [result]
     elif isinstance(result, list):

--- a/app/services/vector.py
+++ b/app/services/vector.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 from pathlib import Path
-from typing import List
+from typing import List, TYPE_CHECKING
 
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 from langchain.schema import Document
-from langchain_community.vectorstores.faiss import FAISS
-from langchain_community.document_loaders import DirectoryLoader, UnstructuredMarkdownLoader, UnstructuredPDFLoader
-from langchain_google_genai import GoogleGenerativeAIEmbeddings
+
+if TYPE_CHECKING:
+    from langchain_community.vectorstores.faiss import FAISS
 
 from app.config import settings
 from app.services.logger import logger
@@ -15,15 +15,18 @@ _DOCS_DIR = Path(settings.DOCS_DIR)
 _VEC_DIR = Path(settings.VECTOR_DIR)
 _MODEL = settings.MODEL_NAME
 
-_RETRIEVER: FAISS | None = None    # cache singleton
+_RETRIEVER: 'FAISS' | None = None    # cache singleton
 
-def get_retriever() -> FAISS:
+def get_retriever() -> 'FAISS':
     global _RETRIEVER
     if _RETRIEVER is not None:
         return _RETRIEVER.as_retriever(search_kwargs={"k": 4})
 
     if (_VEC_DIR / "index.faiss").exists():
         try:
+            from langchain_google_genai import GoogleGenerativeAIEmbeddings
+            from langchain_community.vectorstores.faiss import FAISS
+
             embeddings = GoogleGenerativeAIEmbeddings(model=_MODEL, google_api_key=settings.GEMINI_API_KEY)
             vectordb = FAISS.load_local(str(_VEC_DIR), embeddings)
             logger.info("FAISS index loaded", path=_VEC_DIR)
@@ -41,6 +44,9 @@ def build_index() -> None:
     logger.info("Building vector index from docs", docs_dir=_DOCS_DIR)
     docs = _load_raw_docs()
     split_docs = _split_docs(docs)
+    from langchain_google_genai import GoogleGenerativeAIEmbeddings
+    from langchain_community.vectorstores.faiss import FAISS
+
     embeddings = GoogleGenerativeAIEmbeddings(model=_MODEL, google_api_key=settings.GEMINI_API_KEY)
     vectordb = FAISS.from_documents(split_docs, embeddings)
 
@@ -49,6 +55,12 @@ def build_index() -> None:
     logger.info("Vector index saved", path=_VEC_DIR, total=len(split_docs))
 
 def _load_raw_docs() -> List[Document]:
+    from langchain_community.document_loaders import (
+        DirectoryLoader,
+        UnstructuredMarkdownLoader,
+        UnstructuredPDFLoader,
+    )
+
     loaders = [
         DirectoryLoader(str(_DOCS_DIR), glob="**/*.md", loader_cls=UnstructuredMarkdownLoader),
         DirectoryLoader(str(_DOCS_DIR), glob="**/*.pdf", loader_cls=UnstructuredPDFLoader),


### PR DESCRIPTION
## Summary
- delay expensive FAISS/Gemini imports in vector service
- create search tool lazily to avoid startup work
- import retrieval helpers inside rag agent functions

## Testing
- `python -m py_compile app/services/vector.py app/services/search.py app/agents/rag.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic_settings')*

------
https://chatgpt.com/codex/tasks/task_e_6876147e5840832d95dd29da457a7d99